### PR TITLE
Marked the dist as explicitly deprecated, both in doc and metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+    - Mark dist as deprecated in the metadata and the abstract
 
 0.02 June 23 2012
      - Tell people to use MooseX::Getopt::Strict instead.

--- a/dist.ini
+++ b/dist.ini
@@ -20,5 +20,6 @@ Test::More    = 0
 [@Filter]
 -bundle = @Author::RHOELZ
 -remove = Test::Kwalitee
+[Deprecated]
 [Test::Kwalitee]
 skiptest=use_strict ; we're using Moose

--- a/lib/MooseX/Getopt/Explicit.pm
+++ b/lib/MooseX/Getopt/Explicit.pm
@@ -20,7 +20,7 @@ around _compute_getopt_attrs => sub {
 
 __END__
 
-# ABSTRACT: MooseX::Getopt, but without implicit option generation
+# ABSTRACT: MooseX::Getopt, but without implicit option generation [DEPRECATED]
 
 =head1 SYNOPSIS
 
@@ -50,5 +50,8 @@ order for a command line option to be generated.
 =head1 SEE ALSO
 
 L<MooseX::Getopt>
+
+L<MooseX::Getopt::Strict> - when using this, give attributes
+a C<Getopt> metaclass if you want it to get a command-line option.
 
 =cut


### PR DESCRIPTION
Hi Rob,

This marks the dist as deprecated in the abstract, and also in the dist metadata.

I was assigned this dist in the [Pull Request Challenge](http://cpan-prc.org). Dists with the deprecated metadata aren't ever assigned.

Cheers,
Neil
